### PR TITLE
Coindex keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,32 @@
 
 - install npm / node lts
 - run `npm run package`
+
+## Usage
+
+1. Interactive
+
+To start interactive shell use the flag -i or --interactive and follow the steps.
+
+2. Non-Interactive
+
+By default the binary runs in this mode and generates a random keypair if no flag is passed
+
+# Example: 
+
+
+To generate key from a seed:
+<code>
+./bin/ripple-keygen-macos -s { Seed }
+</code>
+
+To generate multiple keypair:
+<code>
+./ripple-keygen-macos -m {number of keys to be generated}
+</code>
+
+To generate copy all the keys generated in the file:
+Note: this only works with -m flag
+<code>
+./ripple-keygen-macos -m -f {number of keys to be generated}
+</code>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To start interactive shell use the flag -i or --interactive and follow the steps
 
 By default the binary runs in this mode and generates a random keypair if no flag is passed
 
-# Example: 
+## Example: 
 
 
 To generate key from a seed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2372,6 +2372,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stdio": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/stdio/-/stdio-2.1.1.tgz",
+      "integrity": "sha512-ZHO7SD10nZnc2pMN85MPPTCKutXPKH+7Z50B7zt/JRNAHXLbI3BidMc9HFD/j2VupZ8lQdSVJB0ebZSVXC6uXw=="
+    },
     "stream-meter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cli-progress": "3.8.0",
     "colors": "1.4.0",
     "inquirer": "7.1.0",
-    "ripple-keypairs": "1.0.0"
+    "ripple-keypairs": "1.0.0",
+    "stdio": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "colors": "1.4.0",
     "inquirer": "7.1.0",
     "ripple-keypairs": "1.0.0",
-    "stdio": "^2.1.1"
+    "stdio": "2.1.1"
   }
 }


### PR DESCRIPTION
--flags support added for ripple keypair generation 
To generate key from a seed:
<code>
./bin/ripple-keygen-macos -s { Seed }
</code>

To generate multiple keypair:
<code>
./ripple-keygen-macos -m {number of keys to be generated}
</code>

To generate copy all the keys generated in the file:
Note: this only works with -m flag
<code>
./ripple-keygen-macos -m -f {number of keys to be generated}
</code>

Now interactive shell can be triggered using -i